### PR TITLE
Fix VA vs PA in PTE

### DIFF
--- a/sys/arch/riscv/include/machdep.h
+++ b/sys/arch/riscv/include/machdep.h
@@ -55,8 +55,8 @@ riscv_kern_phystov(paddr_t pa)
 	return pa + kern_vtopdiff;
 }
 
-#define KERN_VTOPHYS(va)	riscv_kern_vtophys(va)
-#define KERN_PHYSTOV(pa)	riscv_kern_phystov(pa)
+#define KERN_VTOPHYS(va)	riscv_kern_vtophys((vaddr_t)va)
+#define KERN_PHYSTOV(pa)	riscv_kern_phystov((paddr_t)pa)
 
 
 void	uartputc(int);

--- a/sys/arch/riscv/riscv/riscv_machdep.c
+++ b/sys/arch/riscv/riscv/riscv_machdep.c
@@ -423,8 +423,8 @@ cpu_kernel_vm_init(void)
 
 	paddr_t end = (phys_base + VM_KERNEL_VM_SIZE + 0x200000 - 1) & -0x200000;
 
-	/* L2 PTE with entry for Kernel VA, pointing to L2 PTE */
-	l2_pte[i] = PA_TO_PTE((paddr_t)&l1_pte) | PTE_V;
+	/* L2 PTE with entry for Kernel VA, pointing to L1 PTE */
+	l2_pte[i] = PA_TO_PTE(KERN_VTOPHYS((paddr_t)&l1_pte)) | PTE_V;
 
 	/* L2 PTE with entry for Kernel PA, pointing to L1 PTE */
 	/* i = ((paddr_t)&start >> L2_SHIFT) & Ln_ADDR_MASK; */

--- a/sys/arch/riscv/riscv/riscv_machdep.c
+++ b/sys/arch/riscv/riscv/riscv_machdep.c
@@ -424,7 +424,7 @@ cpu_kernel_vm_init(void)
 	paddr_t end = (phys_base + VM_KERNEL_VM_SIZE + 0x200000 - 1) & -0x200000;
 
 	/* L2 PTE with entry for Kernel VA, pointing to L1 PTE */
-	l2_pte[i] = PA_TO_PTE(KERN_VTOPHYS((paddr_t)&l1_pte)) | PTE_V;
+	l2_pte[i] = PA_TO_PTE(KERN_VTOPHYS(&l1_pte)) | PTE_V;
 
 	/* L2 PTE with entry for Kernel PA, pointing to L1 PTE */
 	/* i = ((paddr_t)&start >> L2_SHIFT) & Ln_ADDR_MASK; */


### PR DESCRIPTION
Store the physical address instead of the virtual address of the kernel
L1 pte in the L2 pte.  Fix a typo in a related comment.